### PR TITLE
convert silent failure when reaching ls_max_fn to stop error.

### DIFF
--- a/R/schmidt.R
+++ b/R/schmidt.R
@@ -265,9 +265,9 @@ schmidt_bracket <- function(alpha, LS_interp, maxLS, funObj, step0, c1, c2,
   }
 
   if (funEvals >= maxLS && !ok) {
-    if (debug) {
-      message("max_fn reached in bracket step")
-    }
+    # if (debug) {
+      stop("ls_max_fn reached in bracket step")
+    # }
   }
 
   list(bracket = bracket_step, done = done, funEvals = funEvals, ok = ok)


### PR DESCRIPTION
This caused me a little headache to figure out where the failure 'bracket_step not found' was coming from. 